### PR TITLE
Added the activeLinkable property to LinkPager class

### DIFF
--- a/LinkPager.php
+++ b/LinkPager.php
@@ -28,6 +28,12 @@ class LinkPager extends \yii\widgets\LinkPager
     public $separator = '...';
 
     /**
+     * @var boolean turns on|off the <a> tag for the active pager item. It is recommended to set it to false
+     * for the sake of Search Engines Optimisation. Defaults to true.
+     */
+    public $activeLinkable = true;
+
+    /**
      * Renders the page buttons.
      * @return string the rendering result
      */
@@ -108,5 +114,37 @@ class LinkPager extends \yii\widgets\LinkPager
         }
 
         return Html::tag('ul', implode("\n", $buttons), $this->options);
+    }
+
+    /**
+     * Renders a page button.
+     * You may override this method to customize the generation of page buttons.
+     * @param string $label the text label for the button
+     * @param integer $page the page number
+     * @param string $class the CSS class for the page button.
+     * @param boolean $disabled whether this page button is disabled
+     * @param boolean $active whether this page button is active
+     * @return string the rendering result
+     */
+    protected function renderPageButton($label, $page, $class, $disabled, $active)
+    {
+        $options = ['class' => $class === '' ? null : $class];
+        if ($active) {
+            Html::addCssClass($options, $this->activePageCssClass);
+        }
+        if ($disabled) {
+            Html::addCssClass($options, $this->disabledPageCssClass);
+
+            return Html::tag('li', Html::tag('span', $label), $options);
+        }
+        $linkOptions = $this->linkOptions;
+        $linkOptions['data-page'] = $page;
+
+        // turn off link for active item
+        if ($active && !$this->activeLinkable) {
+            return Html::tag('li', Html::tag('span', $label, $linkOptions), $options);
+        }
+
+        return Html::tag('li', Html::a($label, $this->pagination->createUrl($page), $linkOptions), $options);
     }
 }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Here is my preferred pager setup.  A max of 7 pages, 'Previous' and 'Next' butto
         'nextPageLabel' => 'Next',
         'prevPageCssClass' => 'prev hidden-xs',
         'nextPageCssClass' => 'next hidden-xs',
+        'activeLinkable' => false,
     ]
 ```
 
 Keep in mind that setting css classes will overwrite the defaults rather than appending to them.  If additional classes should be included (such as the 'hidden-xs' above) the original `prev` and `next` should be included as well (this is the same way the standard LinkPager functions).
+You may turn off the anchor tag in active item by setting `activeLinkable` to false. That helps to avoid the situation when the page links to it self. 


### PR DESCRIPTION
This revision helps to follow SEO recommendation of Google. It sounds that an HTML page must avoid internal links to itself.
